### PR TITLE
-added check-balance ( Ficora extension )

### DIFF
--- a/src/AfriCC/EPP/Extension/Ficora/Check/Balance.php
+++ b/src/AfriCC/EPP/Extension/Ficora/Check/Balance.php
@@ -1,0 +1,26 @@
+<?php
+namespace AfriCC\EPP\Extension\Ficora\Check;
+
+use AfriCC\EPP\ExtensionInterface;
+use AfriCC\EPP\Frame\Command\Check\Domain;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nikolayyotsov
+ * Date: 3/6/17
+ * Time: 10:51 AM
+ */
+class Balance extends Domain implements ExtensionInterface
+{
+    protected $extension_xmlns = 'urn:ietf:params:xml:ns:epp-1.0';
+
+    public function checkBalance()
+    {
+        $this->set("//epp:epp/epp:command/epp:check/balance");
+    }
+
+    public function getExtensionNamespace()
+    {
+        return $this->extension_xmlns;
+    }
+}


### PR DESCRIPTION
Check Balance
Check balance is an extension, where a user can ask for the current account balance. The request contains and empty <balance> element and the response will contain the balance value and the timestamp.
Full request:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 
<command>
  <check>
 
<balance></balance>
 
</check>
 
<clTRID>ABC-12345</clTRID>
 
</command>
</epp>
```
Example response:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 
<response>
 
<result code="10s00">
 
<msg>Command completed successfully</msg>
 
</result>
<resData>
 
<balanceamount>123</balanceamount>
 
<timestamp>1999-04-03T22:00:00.0Z</timestamp>
 
</resData>
 
<trID>
 
<clTRID>ABC-12345</clTRID>
<svTRID>54322-XYZ</svTRID>
 
</trID>
 
</response>
</epp>
```